### PR TITLE
Support for G75VW laptop

### DIFF
--- a/drivers/platform/x86/asus-nb-wmi.c
+++ b/drivers/platform/x86/asus-nb-wmi.c
@@ -63,6 +63,11 @@ static struct quirk_entry quirk_asus_x401u = {
 	.wapf = 4,
 };
 
+/* backlight control is handled by another module, such as nvidiabl */
+static struct quirk_entry quirk_asus_other_backlight = {
+	.other_backlight_power = true
+};
+
 static int dmi_matched(const struct dmi_system_id *dmi)
 {
 	quirks = dmi->driver_data;
@@ -141,6 +146,15 @@ static struct dmi_system_id asus_quirks[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "X55VD"),
 		},
 		.driver_data = &quirk_asus_x401u,
+	},
+	{
+		.callback = dmi_matched,
+		.ident = "ASUSTeK COMPUTER INC. G75VW",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+			DMI_MATCH(DMI_PRODUCT_NAME, "G75VW"),
+		},
+		.driver_data = &quirk_asus_other_backlight
 	},
 	{},
 };

--- a/drivers/platform/x86/asus-wmi.h
+++ b/drivers/platform/x86/asus-wmi.h
@@ -42,6 +42,7 @@ struct quirk_entry {
 	bool scalar_panel_brightness;
 	bool store_backlight_power;
 	bool wmi_backlight_power;
+	bool other_backlight_power;
 	int wapf;
 };
 


### PR DESCRIPTION
Hello.  Thank you for merging in my recent pull request to wmidump.

I have an ASUS G75VW gaming laptop with an nvidia GPU in it (specifically G75VW-DH72).  The backlight power appears to be controlled through the nvidia GPU, because the only way I have found to control the backlight is to use the nvidiabl module, which hasn't yet been merged into the kernel:
https://github.com/guillaumezin/nvidiabl

After loading that module, I was able to control the backlight by writing to /sys/class/backlight/nvidia_backlight/brightness.  However, the backlight hotkeys (Fn+F5 and Fn+F6) didn't work.

After a bit of research, I modified the asus-wmi and asus-nb-wmi modules in order to get  the backlight hotkeys  to work.  Before my modifications, the modules only supported two different paths for hotkey events.  I have drawn the two paths below using function names from the kernel:

Path 1: acpi_wmi_notify -> asus_wmi_notify -> sparse_keymap_report_event -> ... user space ... -> ACPI video driver

Path 2: acpi_wmi_notify -> asus_wmi_notify ->  asus_wmi_backlight_notify -> backlight_force_update

Neither of these paths seemed to work for my laptop.  I really wanted the hotkey events to go into user space and then be sent to the nvidiabl module.  So I added a quirk called "other_backlight_power" for laptops where the backlight power is not controlled by the ACPI video driver and not controlled by WMI.  This allows a third path:

Path 3: acpi_wmi_notify -> asus_wmi_notify -> sparse_keymap_report_event -> ... user space ... -> other module (e.g. nvidiabl)

I have tested these changes on my system and they work:  when I press the backlight hotkeys, the backlight brightness changes and Gnome 3 pops up a little notification window showing the backlight brightness.

I am using boot parameters "acpi_osi=Linux acpi_backlight=vendor" but I think I don't need then.

I hope that issuing a pull request for this repository is the right way to contribute.  Please let me know if you see any issues with this code, I will try to address any concerns.  Please merge these changes in or help me improve them!
# 

Even with these changes, there is still one big problem on my G75VW backlight:  The acpi_wmi_notify method only receives 1 event for every 2 backlight hotkey presses.  The sequence of events looks like this:
1) I press Fn+F6 for the first time and nothing happens.
2) I press Fn+F6 and acpi_wmi_notify is called.
3) I press Fn+F6 and nothing happens.
4) I press Fn+F6 and acpi_wmi_notify is called.
Obviously I don't have the same problem in Windows, so there must be something we could do to fix this, but I am not sure where to look.  I will open an issue at http://dev.iksaif.net/projects/acpi4asus/issues and we can discuss it more there.
